### PR TITLE
Intact Portal large downloads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>11</java.version>
         <spring-boot-admin.version>2.0.0</spring-boot-admin.version>
-        <intact.graphdb.version>3.0.36-SNAPSHOT</intact.graphdb.version>
+        <intact.graphdb.version>3.0.37-SNAPSHOT</intact.graphdb.version>
         <intact.search.interactors.version>1.0.3-SNAPSHOT</intact.search.interactors.version>
         <intact.search.interactions.version>1.1.0-SNAPSHOT</intact.search.interactions.version>
         <intact.search.terms.version>0.0.1-SNAPSHOT</intact.search.terms.version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,14 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-mail</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-neo4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
 <!--        <dependency>-->
 <!--            <groupId>de.codecentric</groupId>-->
 <!--            <artifactId>spring-boot-admin-starter-client</artifactId>-->

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,13 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>psidev.psi.mi.jami</groupId>
+            <artifactId>jami-commons</artifactId>
+            <version>${psi.jami.version}</version>
+            <scope>compile</scope>
+        </dependency>
+
         <!--<dependency>-->
         <!--<groupId>uk.ac.ebi.intact.search</groupId>-->
         <!--<artifactId>intact-search-terms</artifactId>-->

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>uk.ac.ebi.intact.portal</groupId>
     <artifactId>intact-portal-indexer</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>IntAct Portal :: Search Indexer Pipeline</name>
@@ -25,9 +25,10 @@
         <spring-boot-admin.version>2.0.0</spring-boot-admin.version>
         <intact.graphdb.version>3.0.36-SNAPSHOT</intact.graphdb.version>
         <intact.search.interactors.version>1.0.3-SNAPSHOT</intact.search.interactors.version>
-        <intact.search.interactions.version>1.0.8-SNAPSHOT</intact.search.interactions.version>
+        <intact.search.interactions.version>1.1.0-SNAPSHOT</intact.search.interactions.version>
         <intact.search.terms.version>0.0.1-SNAPSHOT</intact.search.terms.version>
         <intact.style.version>1.0.2-SNAPSHOT</intact.style.version>
+        <psi.jami.version>3.2.10</psi.jami.version>
 
         <style.full.index>true</style.full.index>
     </properties>
@@ -64,12 +65,6 @@
             <version>${intact.graphdb.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
-        </dependency>
-
         <!-- Intact Search -->
         <dependency>
             <groupId>uk.ac.ebi.intact.search.interactors</groupId>
@@ -87,6 +82,24 @@
             <groupId>uk.ac.ebi.intact.style</groupId>
             <artifactId>intact-style-service</artifactId>
             <version>${intact.style.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>psidev.psi.mi.jami</groupId>
+            <artifactId>jami-interactionviewer-json</artifactId>
+            <version>${psi.jami.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>psidev.psi.mi.jami.bridges</groupId>
+            <artifactId>jami-ols</artifactId>
+            <version>${psi.jami.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>uk.ac.ebi.pride.architectural</groupId>
+                    <artifactId>pride-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!--<dependency>-->
@@ -173,27 +186,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
-                <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>org.springframework.boot</groupId>
-                            <artifactId>spring-boot-configuration-processor</artifactId>
-                            <version>${spring.version}</version>
-                        </path>
-                        <path>
-                            <groupId>org.projectlombok</groupId>
-                            <artifactId>lombok</artifactId>
-                            <version>${lombok.version}</version>
-                        </path>
-                    </annotationProcessorPaths>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>external.atlassian.jgitflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <intact.search.interactions.version>1.1.1-SNAPSHOT</intact.search.interactions.version>
         <intact.search.terms.version>0.0.1-SNAPSHOT</intact.search.terms.version>
         <intact.style.version>1.0.2-SNAPSHOT</intact.style.version>
-        <psi.jami.version>3.2.10</psi.jami.version>
+        <psi.jami.version>3.4.0-SNAPSHOT</psi.jami.version>
 
         <style.full.index>true</style.full.index>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <intact.search.interactions.version>1.1.0-SNAPSHOT</intact.search.interactions.version>
         <intact.search.terms.version>0.0.1-SNAPSHOT</intact.search.terms.version>
         <intact.style.version>1.0.2-SNAPSHOT</intact.style.version>
-        <psi.jami.version>3.2.10</psi.jami.version>
+        <psi.jami.version>3.3.2-SNAPSHOT</psi.jami.version>
 
         <style.full.index>true</style.full.index>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>11</java.version>
         <spring-boot-admin.version>2.0.0</spring-boot-admin.version>
-        <intact.graphdb.version>3.1.5-SNAPSHOT</intact.graphdb.version>
+        <intact.graphdb.version>3.0.37-SNAPSHOT</intact.graphdb.version>
         <intact.search.interactors.version>1.0.3-SNAPSHOT</intact.search.interactors.version>
         <intact.search.interactions.version>1.1.1-SNAPSHOT</intact.search.interactions.version>
         <intact.search.terms.version>0.0.1-SNAPSHOT</intact.search.terms.version>

--- a/src/main/java/uk/ac/ebi/intact/portal/indexer/interaction/InteractionIndexerTasklet.java
+++ b/src/main/java/uk/ac/ebi/intact/portal/indexer/interaction/InteractionIndexerTasklet.java
@@ -290,7 +290,7 @@ public class InteractionIndexerTasklet implements Tasklet {
 //            Set<String> intactConfidence = new HashSet<String>();
             if (graphClusteredInteraction != null) {
                 GraphConfidence miScoreConfidence = createMiScoreConfidence(graphClusteredInteraction.getMiscore());
-                if (graphBinaryInteractionEvidence.getConfidences() != null) {
+                if (graphBinaryInteractionEvidence.getConfidences() != null && !graphBinaryInteractionEvidence.getConfidences().isEmpty()) {
                     graphBinaryInteractionEvidence.getConfidences().add(miScoreConfidence);
                 } else {
                     graphBinaryInteractionEvidence.setConfidences(Collections.singletonList(miScoreConfidence));

--- a/src/main/java/uk/ac/ebi/intact/portal/indexer/interaction/InteractionIndexerTasklet.java
+++ b/src/main/java/uk/ac/ebi/intact/portal/indexer/interaction/InteractionIndexerTasklet.java
@@ -289,11 +289,16 @@ public class InteractionIndexerTasklet implements Tasklet {
             GraphClusteredInteraction graphClusteredInteraction = graphBinaryInteractionEvidence.getClusteredInteraction();
 //            Set<String> intactConfidence = new HashSet<String>();
             if (graphClusteredInteraction != null) {
-                GraphConfidence miScoreConfidence = createMiScoreConfidence(graphClusteredInteraction.getMiscore());
-                if (graphBinaryInteractionEvidence.getConfidences() != null && !graphBinaryInteractionEvidence.getConfidences().isEmpty()) {
-                    graphBinaryInteractionEvidence.getConfidences().add(miScoreConfidence);
-                } else {
-                    graphBinaryInteractionEvidence.setConfidences(Collections.singletonList(miScoreConfidence));
+                try {
+                    GraphConfidence miScoreConfidence = createMiScoreConfidence(graphClusteredInteraction.getMiscore());
+                    if (graphBinaryInteractionEvidence.getConfidences() != null && !graphBinaryInteractionEvidence.getConfidences().isEmpty()) {
+                        graphBinaryInteractionEvidence.getConfidences().add(miScoreConfidence);
+                    } else {
+                        graphBinaryInteractionEvidence.setConfidences(Collections.singletonList(miScoreConfidence));
+                    }
+                } catch (Exception e) {
+                    log.error("New confidence error");
+                    e.printStackTrace();
                 }
 //                intactConfidence.add("intact-miscore:" + graphClusteredInteraction.getMiscore());
                 searchInteraction.setIntactMiscore(graphClusteredInteraction.getMiscore());
@@ -745,8 +750,8 @@ public class InteractionIndexerTasklet implements Tasklet {
 
     private static GraphConfidence createMiScoreConfidence(double score) {
         return new GraphConfidence(new DefaultConfidence(
-                new GraphCvTerm(new DefaultCvTerm("intact-miscore"), false), Double.toString(score)),
-                false);
+                new GraphCvTerm(new DefaultCvTerm("intact-miscore"), true), Double.toString(score)),
+                true);
 
     }
 }

--- a/src/main/java/uk/ac/ebi/intact/portal/indexer/interaction/InteractionIndexerTasklet.java
+++ b/src/main/java/uk/ac/ebi/intact/portal/indexer/interaction/InteractionIndexerTasklet.java
@@ -32,6 +32,8 @@ import psidev.psi.mi.jami.model.Interactor;
 import psidev.psi.mi.jami.model.Organism;
 import psidev.psi.mi.jami.model.Participant;
 import psidev.psi.mi.jami.model.Publication;
+import psidev.psi.mi.jami.model.impl.DefaultConfidence;
+import psidev.psi.mi.jami.model.impl.DefaultCvTerm;
 import psidev.psi.mi.jami.tab.MitabVersion;
 import psidev.psi.mi.jami.utils.CvTermUtils;
 import psidev.psi.mi.jami.xml.PsiXmlVersion;
@@ -283,9 +285,15 @@ public class InteractionIndexerTasklet implements Tasklet {
             searchInteraction.setBinaryInteractionId(graphBinaryInteractionEvidence.getGraphId());// use binary counter while generating test interactions.xml
             searchInteraction.setDocumentType(DocumentType.INTERACTION);
             GraphClusteredInteraction graphClusteredInteraction = graphBinaryInteractionEvidence.getClusteredInteraction();
-            Set<String> intactConfidence = new HashSet<String>();
+//            Set<String> intactConfidence = new HashSet<String>();
             if (graphClusteredInteraction != null) {
-                intactConfidence.add("intact-miscore:" + graphClusteredInteraction.getMiscore());
+                GraphConfidence miScoreConfidence = createMiScoreConfidence(graphClusteredInteraction.getMiscore());
+                if (graphBinaryInteractionEvidence.getConfidences() != null && !graphBinaryInteractionEvidence.getConfidences().isEmpty()) {
+                    graphBinaryInteractionEvidence.getConfidences().add(miScoreConfidence);
+                } else {
+                    graphBinaryInteractionEvidence.setConfidences(Collections.singletonList(miScoreConfidence));
+                }
+//                intactConfidence.add("intact-miscore:" + graphClusteredInteraction.getMiscore());
                 searchInteraction.setIntactMiscore(graphClusteredInteraction.getMiscore());
                 searchInteraction.setAsIntactMiscore(graphClusteredInteraction.getMiscore());
             }
@@ -297,7 +305,7 @@ public class InteractionIndexerTasklet implements Tasklet {
             interactionIds.addAll(xrefsToASSolrDocument(graphBinaryInteractionEvidence.getIdentifiers()));
             searchInteraction.setAsInteractionIds(!interactionIds.isEmpty() ? interactionIds : null);
 
-            searchInteraction.setConfidenceValues(!intactConfidence.isEmpty() ? intactConfidence : null);
+//            searchInteraction.setConfidenceValues(!intactConfidence.isEmpty() ? intactConfidence : null);
 
             final String shortName = graphBinaryInteractionEvidence.getInteractionType().getShortName();
             searchInteraction.setType(graphBinaryInteractionEvidence.getInteractionType() != null ? shortName : null);
@@ -700,5 +708,12 @@ public class InteractionIndexerTasklet implements Tasklet {
             } catch (Exception e) {
             }
         }
+    }
+
+    private static GraphConfidence createMiScoreConfidence(double score) {
+        return new GraphConfidence(new DefaultConfidence(
+                new GraphCvTerm(new DefaultCvTerm("intact-miscore"), true), Double.toString(score)),
+                true);
+
     }
 }

--- a/src/main/java/uk/ac/ebi/intact/portal/indexer/interaction/InteractionIndexerTasklet.java
+++ b/src/main/java/uk/ac/ebi/intact/portal/indexer/interaction/InteractionIndexerTasklet.java
@@ -33,8 +33,6 @@ import psidev.psi.mi.jami.model.Interactor;
 import psidev.psi.mi.jami.model.Organism;
 import psidev.psi.mi.jami.model.Participant;
 import psidev.psi.mi.jami.model.Publication;
-import psidev.psi.mi.jami.model.impl.DefaultConfidence;
-import psidev.psi.mi.jami.model.impl.DefaultCvTerm;
 import psidev.psi.mi.jami.tab.MitabVersion;
 import psidev.psi.mi.jami.utils.CvTermUtils;
 import psidev.psi.mi.jami.xml.PsiXmlVersion;
@@ -558,25 +556,23 @@ public class InteractionIndexerTasklet implements Tasklet {
 
         cleanBinariesForExport(interactionEvidence);
 
-        Confidence miScoreConfidence = null;
+        Double miScore = null;
         if (graphClusteredInteraction != null) {
-            miScoreConfidence = new DefaultConfidence(
-                    new DefaultCvTerm("intact-miscore"),
-                    Double.toString(graphClusteredInteraction.getMiscore()));
+            miScore = graphClusteredInteraction.getMiscore();
         }
 
-        searchInteraction.setJsonFormat(getInteractionAsFormat(interactionEvidence, miScoreConfidence, SearchInteractionFields.JSON_FORMAT));
-        searchInteraction.setXml25Format(getInteractionAsFormat(interactionEvidence, miScoreConfidence, SearchInteractionFields.XML_25_FORMAT));
-        searchInteraction.setXml30Format(getInteractionAsFormat(interactionEvidence, miScoreConfidence, SearchInteractionFields.XML_30_FORMAT));
-        searchInteraction.setTab25Format(getInteractionAsFormat(interactionEvidence, miScoreConfidence, SearchInteractionFields.TAB_25_FORMAT));
-        searchInteraction.setTab26Format(getInteractionAsFormat(interactionEvidence, miScoreConfidence, SearchInteractionFields.TAB_26_FORMAT));
-        searchInteraction.setTab27Format(getInteractionAsFormat(interactionEvidence, miScoreConfidence, SearchInteractionFields.TAB_27_FORMAT));
+        searchInteraction.setJsonFormat(getInteractionAsFormat(interactionEvidence, miScore, SearchInteractionFields.JSON_FORMAT));
+        searchInteraction.setXml25Format(getInteractionAsFormat(interactionEvidence, miScore, SearchInteractionFields.XML_25_FORMAT));
+        searchInteraction.setXml30Format(getInteractionAsFormat(interactionEvidence, miScore, SearchInteractionFields.XML_30_FORMAT));
+        searchInteraction.setTab25Format(getInteractionAsFormat(interactionEvidence, miScore, SearchInteractionFields.TAB_25_FORMAT));
+        searchInteraction.setTab26Format(getInteractionAsFormat(interactionEvidence, miScore, SearchInteractionFields.TAB_26_FORMAT));
+        searchInteraction.setTab27Format(getInteractionAsFormat(interactionEvidence, miScore, SearchInteractionFields.TAB_27_FORMAT));
     }
 
-    private static String getInteractionAsFormat(BinaryInteractionEvidence interactionEvidence, Confidence miScoreConfidence, String format) {
+    private static String getInteractionAsFormat(BinaryInteractionEvidence interactionEvidence, Double miScore, String format) {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         InteractionWriter writer = createInteractionEvidenceWriterFor(outputStream, format);
-        writer.write(interactionEvidence, miScoreConfidence);
+        writer.write(interactionEvidence, miScore);
         writer.flush();
         return outputStream.toString();
     }

--- a/src/main/java/uk/ac/ebi/intact/portal/indexer/interaction/InteractionIndexerTasklet.java
+++ b/src/main/java/uk/ac/ebi/intact/portal/indexer/interaction/InteractionIndexerTasklet.java
@@ -561,12 +561,42 @@ public class InteractionIndexerTasklet implements Tasklet {
 
     private static void setFormatFields(SearchInteraction searchInteraction, BinaryInteractionEvidence interactionEvidence) {//, GraphClusteredInteraction graphClusteredInteraction) {
         cleanBinariesForExport(interactionEvidence);
-        searchInteraction.setJsonFormat(getInteractionAsFormat(interactionEvidence, SearchInteractionFields.JSON_FORMAT));
-        searchInteraction.setXml25Format(getInteractionAsFormat(interactionEvidence, SearchInteractionFields.XML_25_FORMAT));
-        searchInteraction.setXml30Format(getInteractionAsFormat(interactionEvidence, SearchInteractionFields.XML_30_FORMAT));
-        searchInteraction.setTab25Format(getInteractionAsFormat(interactionEvidence, SearchInteractionFields.TAB_25_FORMAT));
-        searchInteraction.setTab26Format(getInteractionAsFormat(interactionEvidence, SearchInteractionFields.TAB_26_FORMAT));
-        searchInteraction.setTab27Format(getInteractionAsFormat(interactionEvidence, SearchInteractionFields.TAB_27_FORMAT));
+        try {
+            searchInteraction.setJsonFormat(getInteractionAsFormat(interactionEvidence, SearchInteractionFields.JSON_FORMAT));
+        } catch (Exception e) {
+            log.error("JSON_FORMAT error");
+            e.printStackTrace();
+        }
+        try {
+            searchInteraction.setXml25Format(getInteractionAsFormat(interactionEvidence, SearchInteractionFields.XML_25_FORMAT));
+        } catch (Exception e) {
+            log.error("XML_25_FORMAT error");
+            e.printStackTrace();
+        }
+        try {
+            searchInteraction.setXml30Format(getInteractionAsFormat(interactionEvidence, SearchInteractionFields.XML_30_FORMAT));
+        } catch (Exception e) {
+            log.error("XML_30_FORMAT error");
+            e.printStackTrace();
+        }
+        try {
+            searchInteraction.setTab25Format(getInteractionAsFormat(interactionEvidence, SearchInteractionFields.TAB_25_FORMAT));
+        } catch (Exception e) {
+            log.error("TAB_25_FORMAT error");
+            e.printStackTrace();
+        }
+        try {
+            searchInteraction.setTab26Format(getInteractionAsFormat(interactionEvidence, SearchInteractionFields.TAB_26_FORMAT));
+        } catch (Exception e) {
+            log.error("TAB_26_FORMAT error");
+            e.printStackTrace();
+        }
+        try {
+            searchInteraction.setTab27Format(getInteractionAsFormat(interactionEvidence, SearchInteractionFields.TAB_27_FORMAT));
+        } catch (Exception e) {
+            log.error("TAB_27_FORMAT error");
+            e.printStackTrace();
+        }
     }
 
     private static String getInteractionAsFormat(BinaryInteractionEvidence interactionEvidence, String format) {


### PR DESCRIPTION
Serialise interactions on each format and save them to SOLR.

These changes depend on changes in intact-portal-search-interactions for the SOLR document new fields: https://github.com/intact-portal/intact-portal-search-interactions/pull/3
They also depend on changes in intact-portal-graphdb to include the MI score in the serialised interactions https://github.com/intact-portal/intact-portal-graphdb/pull/4

Some changes seem to already be in the advance-search-jj branch, I made them on the other branch and merged them before creating a new branch specifically for this.